### PR TITLE
- force xml version less than 2.6.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ homepage: https://github.com/TOPdesk/dart-junitreport
 documentation:
 
 dependencies:
-  xml: '^2.5.0'
+  xml: '>= 2.5.0 <2.6.0'
   intl: '^0.14.0'
   testreport: '^0.2.0'
   args: '^0.13.7'


### PR DESCRIPTION
xml moved the XmlPrettyWriter into a different library in 2.6, causes junitreport to break.
Provisionally fix is to force old version in the version constraints.