### PR TITLE
Relax dependency on xml to allow newer version

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -378,7 +378,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.7.0"
+    version: "4.2.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,7 +154,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.2.2"
   mime:
     dependency: transitive
     description:
@@ -378,7 +378,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,6 @@
 name: junitreport
 version: 1.3.1-dev
-description:
-  Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to
-  JUnit style XML
+description: Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to JUnit style XML
 
 homepage: https://github.com/TOPdesk/dart-junitreport
 documentation:
@@ -11,14 +9,14 @@ dependencies:
   args: ^1.6.0
   intl: ^0.16.1
   testreport: ^1.2.0
-  xml: ">=3.7.0 <5.0.0"
+  xml: '>=3.7.0 <5.0.0'
 
 dev_dependencies:
   pedantic: ^1.9.0
   test: any
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.7.0 <3.0.0'
 
 executables:
   tojunit:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: junitreport
 version: 1.3.1-dev
-description: Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to
+description:
+  Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to
   JUnit style XML
 
 homepage: https://github.com/TOPdesk/dart-junitreport
@@ -10,14 +11,14 @@ dependencies:
   args: ^1.6.0
   intl: ^0.16.1
   testreport: ^1.2.0
-  xml: ^3.7.0
+  xml: ">=3.7.0 <5.0.0"
 
 dev_dependencies:
   pedantic: ^1.9.0
   test: any
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: ">=2.7.0 <3.0.0"
 
 executables:
   tojunit:


### PR DESCRIPTION
This PR relaxes the version constraint on `xml`, allowing any version from 3.7.0 (the current requirement), into the 4.x series. 

This library doesn't seem to be affected by any of the breaking changes in xml 4.0.0 update

Closes #19 