### PR TITLE
fix: :bug: Remove bad unicode for XML

### DIFF
--- a/lib/src/impl/xml.dart
+++ b/lib/src/impl/xml.dart
@@ -27,7 +27,8 @@ XmlAttribute attr(String name, dynamic value) =>
 
 XmlText txt(String text) => XmlText(text);
 
-String toXmlString(XmlDocument document) => document.toXmlString(
+String toXmlString(XmlDocument document) {
+  final result = document.toXmlString(
       pretty: true,
       preserveWhitespace: (XmlNode node) {
         if (node is! XmlElement) return false;
@@ -35,5 +36,9 @@ String toXmlString(XmlDocument document) => document.toXmlString(
             .contains((node as XmlElement).name.local);
       },
     );
+  // https://stackoverflow.com/questions/1176904/php-how-to-remove-all-non-printable-characters-in-a-string
+  // 0x0d \r 0x0a \n
+  return result.replaceAll(RegExp('[\x00-\x09\x0B-\x1F\x7F]'), '');
+}
 
 XmlName _name(String name) => XmlName.fromString(name);


### PR DESCRIPTION
This PR fix the following potential problem in XML.
```
    <testcase classname="D:.Project.McDedicatedServer.mc_dedicated_server_go.test.app_tests.repository.ngrok_repository" name="Ngrok User start ngrok service." time="0.011">
      <system-out></system-out>
    </testcase>
```

There is similar to space in `<system-out></system-out>`, but actually It's *0x01, SOH(start of headline)*, I have no idea why It produce the strange unicode, but this [post](https://stackoverflow.com/questions/1176904/php-how-to-remove-all-non-printable-characters-in-a-string) help this PR to fix the issue.

> UTF-8?
> Ah, welcome back to the 21st century. If you have a UTF-8 encoded string, then the /u modifier can be used on the regex
> 
> $string = preg_replace('/[\x00-\x1F\x7F]/u', '', $string);
> This just removes 0-31 and 127. This works in ASCII and UTF-8 because both share the same control set range (as noted by mgutt below). Strictly speaking, this would work without the /u modifier. But it makes life easier if you want to remove other chars...
> 
> If you're dealing with Unicode, there are potentially many non-printing elements, but let's consider a simple one: NO-BREAK SPACE (U+00A0)
> 
> In a UTF-8 string, this would be encoded as 0xC2A0. You could look for and remove that specific sequence, but with the /u modifier in place, you can simply add \xA0 to the character class:
> 
> $string = preg_replace('/[\x00-\x1F\x7F\xA0]/u', '', $string);

And I personally kept the `\r` and `\n` in the code, since I think Windows users as me would love to see It 😄 