### PR TITLE
Add test failure stack traces to JUnit reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+* always output stack trace for both test failures and errors
+* separate failure output sections with true newlines
+
 ## 1.3.1
 * updated dependencies:
   * xml: '^4.3.0'

--- a/lib/src/impl/report.dart
+++ b/lib/src/impl/report.dart
@@ -3,10 +3,10 @@
 // license that can be found in the LICENSE file.
 
 import 'package:intl/intl.dart';
-import 'package:xml/xml.dart';
-import 'package:testreport/testreport.dart';
 import 'package:junitreport/junitreport.dart';
 import 'package:junitreport/src/impl/xml.dart';
+import 'package:testreport/testreport.dart';
+import 'package:xml/xml.dart';
 
 class XmlReport implements JUnitReport {
   static final NumberFormat _milliseconds = NumberFormat('#####0.00#', 'en_US');
@@ -160,7 +160,6 @@ class XmlReport implements JUnitReport {
     } else {
       long = message;
     }
-    if (message.isNotEmpty && problem.isFailure) stacktrace = '';
 
     var report = <String>[];
     var type = problem.isFailure ? 'Failure' : 'Error';
@@ -171,7 +170,7 @@ class XmlReport implements JUnitReport {
     }
     if (long != null) report.add(long);
     if (stacktrace.isNotEmpty) report.add('Stacktrace:\n$stacktrace');
-    return report.join(r'\n\n');
+    return report.join('\n\n');
   }
 
   String _message(int failures, int errors) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: junitreport
-version: 1.3.2-dev
+version: 1.4.0
 description: Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to
   JUnit style XML
 

--- a/tool/example.xml
+++ b/tool/example.xml
@@ -12,7 +12,9 @@ and even
 two in one go</system-out>
     </testcase>
     <testcase classname="allresults" name="failing test" time="0.141">
-      <failure message="1 failure, see stacktrace for details">Failure:\n\nExpected: 'two\n'
+      <failure message="1 failure, see stacktrace for details">Failure:
+
+Expected: 'two\n'
   'lines for seeing how it is rendered'
   Actual: 'two\n'
   'lines that are not expected'
@@ -21,10 +23,17 @@ Expected: ... wo\nlines for seeing ...
   Actual: ... wo\nlines that are n ...
                         ^
  Differ at offset 11
+
+
+Stacktrace:
+package:test                                  expect
+tool\example-tests\allresults_test.dart 20:5  main.&lt;fn>
 </failure>
     </testcase>
     <testcase classname="allresults" name="failing test with reason" time="0.03">
-      <failure message="1 failure, see stacktrace for details">Failure:\n\nExpected: 'should fail'
+      <failure message="1 failure, see stacktrace for details">Failure:
+
+Expected: 'should fail'
   Actual: 'fails'
    Which: is different.
 Expected: should fai ...
@@ -32,6 +41,11 @@ Expected: should fai ...
           ^
  Differ at offset 0
 the failure reason
+
+
+Stacktrace:
+package:test                                  expect
+tool\example-tests\allresults_test.dart 25:5  main.&lt;fn>
 </failure>
     </testcase>
     <testcase classname="allresults" name="error in test" time="0.036">
@@ -39,13 +53,20 @@ the failure reason
 </error>
     </testcase>
     <testcase classname="allresults" name="error test and failure" time="0.037">
-      <failure message="1 failure, see stacktrace for details">Failure:\n\nExpected: 'expected1'
+      <failure message="1 failure, see stacktrace for details">Failure:
+
+Expected: 'expected1'
   Actual: 'actual1'
    Which: is different.
 Expected: expected1
   Actual: actual1
           ^
  Differ at offset 0
+
+
+Stacktrace:
+package:test                                  expect
+tool\example-tests\allresults_test.dart 33:5  main.&lt;fn>
 </failure>
     </testcase>
     <testcase classname="allresults" name="skipped top level test" time="0.00">


### PR DESCRIPTION
Stack traces were previously deliberately excluded from the JUnit output when a test failed an expectation like `expect(true, false)`. Stack traces were only included when an unexpected error was encountered while running the test. 

This change includes the stack trace in the JUnit output for test failures, as well as test errors. 

An example of where stack traces for test failures may be useful: consider a large application that is using helper methods to verify common behaviour. In this case the failing expectation may not be collocated with the failing test, so having the stack trace is crucial in quickly finding where the issue is occurring. 

Also swapped the escaped newline characters in the error for true newlines, which produces a cleaner output. 

Fixes #14 