### PR TITLE
Bump libraries and migrate code to null-safety

### DIFF
--- a/bin/tojunit.dart
+++ b/bin/tojunit.dart
@@ -11,14 +11,14 @@ import 'package:junitreport/junitreport.dart';
 import 'package:testreport/testreport.dart';
 
 Future<Null> main(List<String> args) async {
-  var arguments = parseArguments(args);
+  var arguments = parseArguments(args)!;
 
-  var lines = LineSplitter().bind(utf8.decoder.bind(arguments.source));
+  var lines = LineSplitter().bind(utf8.decoder.bind(arguments.source!));
   try {
     var report = await createReport(arguments, lines);
     var xml = JUnitReport(base: arguments.base, package: arguments.package)
         .toXml(report);
-    arguments.target.write(xml);
+    arguments.target!.write(xml);
   } catch (e) {
     stderr.writeln(e.toString());
     exit(1);
@@ -26,7 +26,7 @@ Future<Null> main(List<String> args) async {
 }
 
 Future<Report> createReport(Arguments arguments, Stream<String> lines) async {
-  var processor = Processor(timestamp: arguments.timestamp);
+  var processor = Processor(timestamp: arguments.timestamp!);
   await for (String line in lines) {
     if (!line.startsWith('{')) {
       continue;
@@ -36,7 +36,7 @@ Future<Report> createReport(Arguments arguments, Stream<String> lines) async {
   return processor.report;
 }
 
-Arguments parseArguments(List<String> args) {
+Arguments? parseArguments(List<String> args) {
   var parser = ArgParser()
     ..addOption('input', abbr: 'i', help: """
 the path to the 'json' file containing the output of 'pub run test'.
@@ -71,16 +71,15 @@ the timestamp to be used in the report
     if (result['help'] as bool) {
       print(parser.usage);
       exit(0);
-      return null; // satisfy code analyzers
     }
 
-    var source = _processInput(result['input'] as String);
-    var target = _processOutput(result['output'] as String);
+    var source = _processInput(result['input'] as String?)!;
+    var target = _processOutput(result['output'] as String?);
 
-    var timestamp = _processTimestamp(result['timestamp'] as String, source);
+    var timestamp = _processTimestamp(result['timestamp'] as String?, source);
     var package = _processPackage(result);
     return Arguments()
-      ..base = result['base'] as String
+      ..base = result['base'] as String?
       ..package = package
       ..timestamp = timestamp
       ..source = source.source
@@ -90,7 +89,6 @@ the timestamp to be used in the report
     print('\nValid program arguments: ');
     print(parser.usage);
     exit(1);
-    return null; // satisfy code analyzers
   }
 }
 
@@ -100,7 +98,7 @@ String _processPackage(ArgResults result) {
   return package;
 }
 
-DateTime _processTimestamp(String timestamp, _Source source) {
+DateTime? _processTimestamp(String? timestamp, _Source source) {
   if (timestamp == null) {
     return source.timestamp;
   }
@@ -115,7 +113,7 @@ DateTime _processTimestamp(String timestamp, _Source source) {
   }
 }
 
-_Source _processInput(String input) {
+_Source? _processInput(String? input) {
   if (input == null) {
     return _Source()
       ..source = stdin
@@ -125,7 +123,6 @@ _Source _processInput(String input) {
   if (!file.existsSync()) {
     stderr.writeln("File '$input' (${file.absolute.path}) does not exist");
     exit(1);
-    return null; // satisfy code analyzers
   }
   try {
     return _Source()
@@ -134,11 +131,10 @@ _Source _processInput(String input) {
   } catch (e) {
     stderr.writeln("Cannot read file '$input' (${file.absolute.path})");
     exit(1);
-    return null; // satisfy code analyzers
   }
 }
 
-IOSink _processOutput(String output) {
+IOSink? _processOutput(String? output) {
   if (output == null) return stdout;
   var file = File(output);
   try {
@@ -146,19 +142,18 @@ IOSink _processOutput(String output) {
   } catch (e) {
     stderr.writeln("Cannot write to file '$output' (${file.absolute.path})");
     exit(1);
-    return null; // satisfy code analyzers
   }
 }
 
 class Arguments {
-  Stream<List<int>> source;
-  IOSink target;
-  DateTime timestamp;
-  String base;
-  String package;
+  Stream<List<int>>? source;
+  IOSink? target;
+  DateTime? timestamp;
+  String? base;
+  String? package;
 }
 
 class _Source {
-  Stream<List<int>> source;
-  DateTime timestamp;
+  Stream<List<int>>? source;
+  DateTime? timestamp;
 }

--- a/lib/src/api/junitreport.dart
+++ b/lib/src/api/junitreport.dart
@@ -13,7 +13,7 @@ abstract class JUnitReport {
   ///
   /// To modify this path, [base] will be removed from it,
   /// and [package] will be prepended.
-  factory JUnitReport({String base, String package}) =>
+  factory JUnitReport({String? base, String? package}) =>
       XmlReport(base, package);
 
   /// Transforms the given [Reports] to an xml String.

--- a/lib/src/impl/report.dart
+++ b/lib/src/impl/report.dart
@@ -17,8 +17,8 @@ class XmlReport implements JUnitReport {
   static const Map<String, dynamic> _noAttributes = <String, dynamic>{};
   static const Iterable<XmlNode> _noChildren = <XmlNode>[];
 
-  final String base;
-  final String package;
+  final String? base;
+  final String? package;
 
   XmlReport(this.base, this.package);
 
@@ -83,18 +83,18 @@ class XmlReport implements JUnitReport {
       main = path;
     }
 
-    if (base.isNotEmpty && main.startsWith(base)) {
-      main = main.substring(base.length);
+    if (base!.isNotEmpty && main.startsWith(base!)) {
+      main = main.substring(base!.length);
       while (main.startsWith(_pathSeparator)) {
         main = main.substring(1);
       }
     }
-    return package +
+    return package! +
         main.replaceAll(_pathSeparator, '.').replaceAll(_dash, '_');
   }
 
   List<XmlNode> _suiteChildren(
-      String platform, Iterable<XmlNode> cases, Iterable<XmlNode> prints) {
+      String? platform, Iterable<XmlNode> cases, Iterable<XmlNode> prints) {
     var properties =
         platform == null ? <XmlNode>[] : <XmlNode>[(_properties(platform))];
     return properties..addAll(cases)..addAll(prints);
@@ -118,9 +118,9 @@ class XmlReport implements JUnitReport {
   XmlElement _problems(Iterable<Problem> problems) {
     if (problems.length == 1) {
       var problem = problems.first;
-      var message = problem.message;
+      final String? message = problem.message;
       if (message != null && !message.contains('\n')) {
-        var stacktrace = problem.stacktrace;
+        final String? stacktrace = problem.stacktrace;
         return elem(
             problem.isFailure ? 'failure' : 'error',
             <String, dynamic>{'message': message},
@@ -152,7 +152,7 @@ class XmlReport implements JUnitReport {
     var message = problem.message ?? '';
     var stacktrace = problem.stacktrace ?? '';
     var short = '';
-    String long;
+    String? long;
     if (message.isEmpty) {
       if (stacktrace.isEmpty) short = ' no details available';
     } else if (!message.contains('\n')) {

--- a/lib/src/impl/xml.dart
+++ b/lib/src/impl/xml.dart
@@ -32,7 +32,7 @@ String toXmlString(XmlDocument document) => document.toXmlString(
       preserveWhitespace: (XmlNode node) {
         if (node is! XmlElement) return false;
         return ['system-out', 'error', 'failure']
-            .contains((node as XmlElement).name.local);
+            .contains(node.name.local);
       },
     );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,329 +7,308 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "19.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.17"
+    version: "1.3.0"
   args:
     dependency: "direct main"
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "1.0.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  csslib:
+    version: "3.0.1"
+  file:
     dependency: transitive
     description:
-      name: csslib
+      name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.2"
+    version: "6.1.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.2"
+    version: "2.0.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.0"
   intl:
     dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.9"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.12"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.2"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "2.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.7"
+    version: "1.1.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.3"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.18"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11"
+    version: "0.3.19"
   testreport:
     dependency: "direct main"
     description:
@@ -343,48 +322,48 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "6.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "1.0.0"
   xml:
     dependency: "direct main"
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "5.0.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: junitreport
-version: 1.3.2
+version: 1.3.3
 description: Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to
   JUnit style XML
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: junitreport
-version: 1.3.2-dev
+version: 1.3.2
 description: Generate JUnit XML reports from dart test runs. Transforms the output of dart or flutter tests to
   JUnit style XML
 
@@ -7,17 +7,17 @@ homepage: https://github.com/TOPdesk/dart-junitreport
 documentation:
 
 dependencies:
-  args: ^1.6.0
-  intl: ^0.16.1
+  args: ^2.0.0
+  intl: ^0.17.0
   testreport: ^1.2.0
-  xml: ^4.3.0
+  xml: ^5.0.2
 
 dev_dependencies:
-  pedantic: ^1.9.0
-  test: any
+  pedantic: ^1.11.0
+  test: ^1.16.8
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 executables:
   tojunit:


### PR DESCRIPTION
This library is not fully migrated to null-safety because of `testreport` dependency that is not null-safety yet. I can fork it too and bump in another PR.